### PR TITLE
Fix compatibility with Mac OS X

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -2,8 +2,13 @@ typeset -gA _dwim_data_regex
 typeset -gA _dwim_data_sed
 typeset -gA _dwim_data_exitstatus
 
-_dwim_sed() {
-  BUFFER=$(echo $BUFFER | sed -re "$1")
+_dwim_sed(){
+  if (( $+commands[gsed] )); then
+      sed_bin='gsed'
+    else
+      sed_bin='sed'
+  fi
+  BUFFER=$(echo $BUFFER | $sed_bin -re "$1")
 }
 
 _dwim_add_transform(){


### PR DESCRIPTION
OS X's default `sed` doesn't support the `-r` flag, and gives this error when trying to use dwim:

>  sed: illegal option -- r

This can be fixed by installing gnu-sed from Homebrew or MacPorts, but the binary name for gnu sed is `gsed` to prevent conflicts with the system version.
This change will use `gsed` if available, allowing it to work on Macs that have gnu sed installed.
