### PR TITLE
Add symlink for oh-my-zsh integration

### DIFF
--- a/zsh-dwim.plugin.zsh
+++ b/zsh-dwim.plugin.zsh
@@ -1,0 +1,1 @@
+init.zsh


### PR DESCRIPTION
This helps with oh-my-zsh integration, as you can clone the repository in the `oh-my-zsh/custom/plugins` folder (to load the plugin, need to add `plugins+=zsh-dwim` to zshrc before loading oh-my-zsh). The `zaw` and `zsh-syntax-highlighting` plugins do the same.

I can also add a note about this to the oh-my-zsh section in the README, if you want.
