### PR TITLE
Switch from which to hash and remove subprocesses

### DIFF
--- a/config.zsh
+++ b/config.zsh
@@ -7,12 +7,12 @@ bindkey "^U" dwim
 ## Checks exist to make sure inappropriate transformations aren't
 ## offered when the zsh-dwim key is pressed
 
-[[ -e "$(which apt-get)" ]] &&
+hash apt-get &>/dev/null &&
   source "$_dwim_transform_dir/apt.zsh"
 
 source "$_dwim_transform_dir/cd.zsh"
 
-[[ -e "$(which dstat)" ]] &&
+hash dstat &>/dev/null &&
   source "$_dwim_transform_dir/dstat.zsh"
 
 source "$_dwim_transform_dir/echo.zsh"
@@ -21,23 +21,24 @@ source "$_dwim_transform_dir/find.zsh"
 
 source "$_dwim_transform_dir/ls.zsh"
 
-[[ -e "$(which modprobe)" ]] &&
+hash modprobe &>/dev/null &&
   source "$_dwim_transform_dir/modprobe.zsh"
 
-[[ -e "$(which mount)" ]] &&
+hash mount &>/dev/null &&
   source "$_dwim_transform_dir/mount.zsh"
 
-[[ -e "$(which rsync)" ]] &&
+hash rsync &>/dev/null &&
   source "$_dwim_transform_dir/rsync.zsh"
 
-[[ -e "$(which ssh)" ]] &&
+hash ssh &>/dev/null &&
   source "$_dwim_transform_dir/ssh.zsh"
 
-[[ -e "$(which service)" ]] &&
+hash service &>/dev/null &&
   source "$_dwim_transform_dir/service.zsh"
 
 source "$_dwim_transform_dir/tar.zsh"
 
-[[ -e "$(which wine)" ]] &&
+hash wine &>/dev/null &&
   source "$_dwim_transform_dir/wine.zsh"
 
+  


### PR DESCRIPTION
Switched from `which` to `hash`. (`hash` also adds the entry to the hash table which speeds up later calls).
Dropped subprocesses `$( ... )` and conditions `[[ ... ]]` which improves performance (all commands are done in the same process)
Suppressed error messages (should the command not be found) with `&>/dev/null`

Of course, if any of this is bad, please tell me so I can make it better. :)
