### PR TITLE
Transformation for cp

### DIFF
--- a/config.zsh
+++ b/config.zsh
@@ -12,6 +12,8 @@ hash apt-get &>/dev/null &&
 
 source "$_dwim_transform_dir/cd.zsh"
 
+source "$_dwim_transform_dir/cp.zsh"
+
 source "$_dwim_transform_dir/chmod.zsh"
 
 source "$_dwim_transform_dir/chattr.zsh"

--- a/transform.d/cp.zsh
+++ b/transform.d/cp.zsh
@@ -1,0 +1,4 @@
+# cp -> cp -R on failure
+_dwim_prepend_transform '^cp ' \
+  '_dwim_sed "s/^cp /cp -R /"' \
+  1


### PR DESCRIPTION
cp -> cp -R on failures. I couldn't think of a way of checking
whether the second argument is a directory.